### PR TITLE
Fix potentially incorrect blending when rendering HUD

### DIFF
--- a/common/src/main/java/cn/zbx1425/minopp/gui/GameOverlayLayer.java
+++ b/common/src/main/java/cn/zbx1425/minopp/gui/GameOverlayLayer.java
@@ -216,7 +216,6 @@ public class GameOverlayLayer implements LayeredDraw.Layer {
      */
     private boolean renderHandCards(GuiGraphics guiGraphics, DeltaTracker deltaTracker) {
         if (Minecraft.getInstance().options.hideGui) return false;
-        RenderSystem.enableBlend();
 
         Font font = Minecraft.getInstance().font;
         LocalPlayer player = Minecraft.getInstance().player;
@@ -248,6 +247,7 @@ public class GameOverlayLayer implements LayeredDraw.Layer {
         }
         handCardCurrentXOff.keySet().removeIf(hash -> !handCardHashes.contains(hash));
 
+        RenderSystem.enableBlend();
         int width = Minecraft.getInstance().getWindow().getGuiScaledWidth();
         int height = Minecraft.getInstance().getWindow().getGuiScaledHeight();
         int handSize = realPlayer.hand.size();


### PR DESCRIPTION
If `renderHands()` returns early (e.g. When no game are in progress), the blend won't be reset after enabling, potentially causing weird rendering artifacts:
![image](https://github.com/user-attachments/assets/79f4fb13-1a42-4148-81fc-fe933c9a7bc5)

This PR moves the line towards just before the actual rendering to alleviate the issue