### PR TITLE
fix: wrong mixin compat ver

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.compile.nullAnalysis.mode": "automatic"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "java.compile.nullAnalysis.mode": "automatic"
-}

--- a/fabric/src/main/resources/minopp.fabric.mixins.json
+++ b/fabric/src/main/resources/minopp.fabric.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "cn.zbx1425.minopp.fabric.mixin",
-  "compatibilityLevel": "JAVA_21",
+  "compatibilityLevel": "JAVA_17",
   "minVersion": "0.8",
   "client": [
     "AbstractClientPlayerMixin"


### PR DESCRIPTION
Changing compatibilityLevel from Java 21 to 17 because 1.20.1 can't be run on Java 21.

Fixes crashes on Fabric loader.